### PR TITLE
fix(hero): adjusted responsive padding to prevent navbar overlaping issue

### DIFF
--- a/app/_components/hero.tsx
+++ b/app/_components/hero.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link'
 
 const Hero = () => {
   return (
-    <section className="relative min-h-screen flex flex-col justify-center items-center bg-gradient-to-br from-[#EEDFFF] via-[#E4CAFF] to-[#DBB5FF] text-white overflow-hidden">
+   <section className="relative min-h-screen flex flex-col justify-center items-center bg-gradient-to-br from-[#EEDFFF] via-[#E4CAFF] to-[#DBB5FF] text-white overflow-hidden pt-24 md:pt-28 xl:pt-0 px-4 md:px-8">
       {/* Background glowing orbs */}
       <div className="absolute inset-0 pointer-events-none">
         <div className="absolute top-24 left-16 w-36 h-36 bg-purple-300/20 rounded-full blur-3xl" />


### PR DESCRIPTION
## 🔗 Related Issue
N/A

## 🎯 Rationale
Fixes an issue where the hero section text overlapped with the navbar on laptop (1024px) view and was misaligned on tablet.

## 📝 Summary of Changes
- Updated `app/_components/hero.tsx`
- 
## ✅ Testing
- Manually tested on mobile (375px), tablet (768px), laptop (1024px), and desktop (≥1280px)
- Verified no overlap with navbar
- Verified consistent spacing across breakpoints

## 📸 Screenshots/Demo
<img width="1502" height="706" alt="lab_small" src="https://github.com/user-attachments/assets/819c8a05-0cb3-4476-87b5-62f1b5bcae27" />
<img width="761" height="665" alt="mobiel2" src="https://github.com/user-attachments/assets/6cd60e1c-7780-4868-b012-02d102eafc5a" />
<img width="555" height="671" alt="monile_view" src="https://github.com/user-attachments/assets/cc43d030-b095-43f4-bdad-8a9e3488110f" />


